### PR TITLE
Intruduced basic CMake configuration

### DIFF
--- a/BoostFunctionalConfig.cmake
+++ b/BoostFunctionalConfig.cmake
@@ -1,0 +1,17 @@
+# Copyright 2018 Thomas Jandecka
+# Distributed under the Boost Software License, Version 1.0.
+# See accompanying file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt
+
+include(CMakeFindDependencyMacro)
+find_dependency(BoostAssert 1.66)
+find_dependency(BoostConfig 1.66)
+find_dependency(BoostCore 1.66)
+find_dependency(BoostInteger 1.66)
+find_dependency(BoostStaticAssert 1.66)
+find_dependency(BoostMpl 1.66)
+find_dependency(BoostPreprocessor 1.66)
+find_dependency(BoostTypeof 1.66)
+find_dependency(BoostTypeTraits 1.66)
+find_dependency(BoostDetail 1.66)
+find_dependency(BoostUtility 1.66)
+include("${CMAKE_CURRENT_LIST_DIR}/BoostFunctionalTargets.cmake")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,67 @@
+# Copyright 2018 Thomas Jandecka
+# Distributed under the Boost Software License, Version 1.0.
+# See accompanying file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt
+
+cmake_minimum_required(VERSION 3.5 FATAL_ERROR)
+
+project(BoostFunctional VERSION 1.66 LANGUAGES CXX)
+
+add_library(functional INTERFACE)
+
+target_include_directories(functional INTERFACE 
+    $<BUILD_INTERFACE:${BoostFunctional_BINARY_DIR}/include>
+    $<BUILD_INTERFACE:${BoostFunctional_SOURCE_DIR}/include>
+    $<INSTALL_INTERFACE:include>
+    )
+
+find_package(BoostAssert 1.66 REQUIRED)
+find_package(BoostConfig 1.66 REQUIRED)
+find_package(BoostCore 1.66 REQUIRED)
+find_package(BoostInteger 1.66 REQUIRED)
+find_package(BoostStaticAssert 1.66 REQUIRED)
+find_package(BoostMpl 1.66 REQUIRED)
+find_package(BoostPreprocessor 1.66 REQUIRED)
+find_package(BoostTypeof 1.66 REQUIRED)
+find_package(BoostTypeTraits 1.66 REQUIRED)
+find_package(BoostDetail 1.66 REQUIRED)
+find_package(BoostUtility 1.66 REQUIRED)
+
+target_link_libraries(functional
+    INTERFACE
+        Boost::assert
+        Boost::config
+        Boost::core
+        Boost::integer
+        Boost::static_assert
+        Boost::mpl
+        Boost::preprocessor
+        Boost::type_traits
+        Boost::utility
+        Boost::detail
+    )
+
+install(EXPORT functional-targets
+    FILE BoostFunctionalTargets.cmake
+    NAMESPACE Boost::
+    DESTINATION lib/cmake/boost
+    )
+
+install(TARGETS functional EXPORT functional-targets
+    INCLUDES DESTINATION include
+    )
+
+include(CMakePackageConfigHelpers)
+write_basic_package_version_file("BoostFunctionalConfigVersion.cmake"
+    VERSION ${BoostFunctional_VERSION}
+    COMPATIBILITY SameMajorVersion
+    )
+install(
+    FILES
+        "BoostFunctionalConfig.cmake"
+        "${CMAKE_CURRENT_BINARY_DIR}/BoostFunctionalConfigVersion.cmake"
+    DESTINATION
+        lib/cmake/boost
+    )
+install(DIRECTORY include/ DESTINATION include)
+
+add_library(Boost::functional ALIAS functional)


### PR DESCRIPTION
Expresses Boost::functional as an `INTERFACE` library in CMake.
- use via `add_subdirectory` 
- use via `find_package(BoostFunctional 1.66)` if previously installed. This is achieved via the following install:
```
$INSTALL_PREFIX
├── include
│   └── boost
│       ├── functional
│       │   ├── factory.hpp
│       │   ├── forward_adapter.hpp
│       │   ├── hash
│       │   │   ├── detail
│       │   │   │   ├── float_functions.hpp
│       │   │   │   ├── hash_float.hpp
│       │   │   │   └── limits.hpp
│       │   │   ├── extensions.hpp
│       │   │   ├── hash_fwd.hpp
│       │   │   └── hash.hpp
│       │   ├── hash_fwd.hpp
│       │   ├── hash.hpp
│       │   ├── lightweight_forward_adapter.hpp
│       │   ├── overloaded_function
│       │   │   ├── config.hpp
│       │   │   └── detail
│       │   │       ├── base.hpp
│       │   │       └── function_type.hpp
│       │   ├── overloaded_function.hpp
│       │   └── value_factory.hpp
│       └── functional.hpp
└── lib
    └── cmake
        └── boost
            ├── BoostFunctionalConfig.cmake
            ├── BoostFunctionalConfigVersion.cmake
            └── BoostFunctionalTargets.cmake

10 directories, 20 files
```
- tests are __not__ included in the build